### PR TITLE
Fix invisible plaintext codeblocks

### DIFF
--- a/src/routes/gpt/Chat/CodeBlock.svelte
+++ b/src/routes/gpt/Chat/CodeBlock.svelte
@@ -14,5 +14,5 @@
 </script>
 
 {#key text}
-	<CodeBlock code={text} language={lang} />
+	<CodeBlock code={text} language={lang ? lang : 'plaintext'} />
 {/key}


### PR DESCRIPTION
This pull request fixes an issue where plaintext codeblocks were not being displayed correctly. The `CodeBlock` component in the `Chat` folder has been updated to ensure that the language is set to 'plaintext' when no language is specified.